### PR TITLE
#9: explicit the message flow and remove normative keywords in Section 3

### DIFF
--- a/draft-ietf-ace-coap-est-oscore.md
+++ b/draft-ietf-ace-coap-est-oscore.md
@@ -145,13 +145,16 @@ One example of specifying more compact alternatives to X.509 certificates for ex
 This specification replaces, or complements, the DTLS handshake in EST-coaps with the lightweight authenticated key exchange protocol EDHOC {{I-D.ietf-lake-edhoc}}.
 During initial enrollment, the EST-oscore client and server run EDHOC {{I-D.ietf-lake-edhoc}} to authenticate and establish the OSCORE Security Context used to protect the messages conveying EST payloads.
 
-The EST-oscore clients and servers MUST perform mutual authentication.
+The EST-oscore client MUST play the role of the EDHOC Initiator.
+The EST-oscore server MUST play the role of the EDHOC Responder.
+
+The EST-oscore clients and servers must perform mutual authentication.
 The EST server and EST client are responsible for ensuring that an acceptable cipher suite is negotiated.
-The client MUST authenticate the server before accepting any server response.
-The server MUST authenticate the client.
+The client must authenticate the server before accepting any server response.
+The server must authenticate the client.
 These requirements are fullfilled when using EDHOC {{I-D.ietf-lake-edhoc}}.
 
-The server MUST also provide relevant information to the CA for decision about issuing a certificate.
+The server must also provide relevant information to the CA for decision about issuing a certificate.
 
 ## EDHOC
 


### PR DESCRIPTION
The commit lowercases the normative keywords in Section 3 to avoid "restatement anti-pattern".